### PR TITLE
Centralize error handling and prune dead null-checks

### DIFF
--- a/Channels/Batch.cs
+++ b/Channels/Batch.cs
@@ -1,4 +1,4 @@
-﻿using SaferPay.Config;
+using SaferPay.Config;
 using SaferPay.Interfaces;
 using SaferPay.Models.Batch;
 using SaferPay.Models.Core;
@@ -11,19 +11,14 @@ public class Batch : IBatch
     private readonly ISaferPayClient _client;
 
     public Batch(SaferPaySettings settings) => _client = new SaferPayClient(settings);
-    public Batch(ISaferPayClient client) => _client = client;
-    public Batch(string customerId, string terminalId, string userName, string passWord, bool sandBox = false) => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
+    public Batch(ISaferPayClient client) => _client = client ?? throw new ArgumentNullException(nameof(client));
+    public Batch(string customerId, string terminalId, string userName, string passWord, bool sandBox = false)
+        => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
 
 
-    public BatchResponse Close(BatchRequest request)
-    {
-        if (_client != null) return _client.Send<BatchResponse, BatchRequest>(SaferPayEndpoints.BatchEndpoint + SaferPayMethods.BatchClose, request);
-        return null;
-    }
+    public BatchResponse Close(BatchRequest request) =>
+        _client.Send<BatchResponse, BatchRequest>(SaferPayEndpoints.BatchEndpoint + SaferPayMethods.BatchClose, request);
 
-    public Task<BatchResponse> CloseAsync(BatchRequest request)
-    {
-        if (_client != null) return _client.SendAsync<BatchResponse, BatchRequest>(SaferPayEndpoints.BatchEndpoint + SaferPayMethods.BatchClose, request);
-        return null;
-    }
+    public Task<BatchResponse> CloseAsync(BatchRequest request) =>
+        _client.SendAsync<BatchResponse, BatchRequest>(SaferPayEndpoints.BatchEndpoint + SaferPayMethods.BatchClose, request);
 }

--- a/Channels/ManagementApi.cs
+++ b/Channels/ManagementApi.cs
@@ -1,4 +1,4 @@
-﻿using SaferPay.Interfaces;
+using SaferPay.Interfaces;
 using SaferPay.Models.Core;
 using SaferPay.Models.Management;
 
@@ -10,163 +10,98 @@ public class ManagementApi : IManagementApi
 
     public ManagementApi(SaferPaySettings settings) => _client = new SaferPayClient(settings);
 
-    public ManagementApi(ISaferPayClient client) => _client = client;
+    public ManagementApi(ISaferPayClient client) => _client = client ?? throw new ArgumentNullException(nameof(client));
 
-    public ManagementApi(string customerId, string terminalId, string userName, string passWord, bool sandBox = false) => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
+    public ManagementApi(string customerId, string terminalId, string userName, string passWord, bool sandBox = false)
+        => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
 
-    public ManagementBaseResponse LicensingCustomerLicense()
+    public ManagementBaseResponse LicensingCustomerLicense() =>
+        LicensingCustomerLicenseAsync().GetAwaiter().GetResult();
+
+    public Task<ManagementBaseResponse> LicensingCustomerLicenseAsync()
     {
-        if (_client == null) return default;
-        var data = LicensingCustomerLicenseAsync().GetAwaiter().GetResult();
-        return data;
-    }
-
-    public async Task<ManagementBaseResponse> LicensingCustomerLicenseAsync()
-    {
-        if (_client == null) return default;
         var endpoint = $"rest/customers/{_client.CustomerId}/license";
-
-        var response = await _client.GetAsync<ManagementBaseResponse>(endpoint);
-        return response;
+        return _client.GetAsync<ManagementBaseResponse>(endpoint);
     }
 
-    public RestResponseBase LicensingCustomerLicenseConfiguration()
-    {
-        if (_client == null) return default;
-        var data = LicensingCustomerLicenseConfigurationAsync().GetAwaiter().GetResult();
-        return data;
-    }
+    public RestResponseBase LicensingCustomerLicenseConfiguration() =>
+        LicensingCustomerLicenseConfigurationAsync().GetAwaiter().GetResult();
 
-    public async Task<RestResponseBase> LicensingCustomerLicenseConfigurationAsync()
+    public Task<RestResponseBase> LicensingCustomerLicenseConfigurationAsync()
     {
-        if (_client == null) return default;
         var endpoint = $"rest/customers/{_client.CustomerId}/license-configuration";
-
-        var response = await _client.GetAsync<RestResponseBase>(endpoint);
-        return response;
+        return _client.GetAsync<RestResponseBase>(endpoint);
     }
 
-    public ManagementConfigurations PaymentPageConfigGetConfigurations()
-    {
-        if (_client == null) return default;
-        var data = PaymentPageConfigGetConfigurationsAsync().GetAwaiter().GetResult();
-        return data;
-    }
+    public ManagementConfigurations PaymentPageConfigGetConfigurations() =>
+        PaymentPageConfigGetConfigurationsAsync().GetAwaiter().GetResult();
 
-    public async Task<ManagementConfigurations> PaymentPageConfigGetConfigurationsAsync()
+    public Task<ManagementConfigurations> PaymentPageConfigGetConfigurationsAsync()
     {
-        if (_client == null) return default;
         var endpoint = $"rest/customers/{_client.CustomerId}/payment-page/configurations";
-
-        var response = await _client.GetAsync<ManagementConfigurations>(endpoint);
-        return response;
+        return _client.GetAsync<ManagementConfigurations>(endpoint);
     }
 
-    public CreateAccessTokenResponse SaferpayFieldsAccessTokenCreateAccessToken(CreateAccessTokenRequest request)
-    {
-        if (_client == null) return default;
-        var data = SaferpayFieldsAccessTokenCreateAccessTokenAsync(request).GetAwaiter().GetResult();
-        return data;
-    }
+    public CreateAccessTokenResponse SaferpayFieldsAccessTokenCreateAccessToken(CreateAccessTokenRequest request) =>
+        SaferpayFieldsAccessTokenCreateAccessTokenAsync(request).GetAwaiter().GetResult();
 
-    public async Task<CreateAccessTokenResponse> SaferpayFieldsAccessTokenCreateAccessTokenAsync(CreateAccessTokenRequest request)
+    public Task<CreateAccessTokenResponse> SaferpayFieldsAccessTokenCreateAccessTokenAsync(CreateAccessTokenRequest request)
     {
-        if (_client == null) return default;
         var endpoint = $"rest/customers/{_client.CustomerId}/terminals/{_client.TerminalId}/fields-access-tokens";
-
-        var response = await _client.PostAsync<CreateAccessTokenResponse, CreateAccessTokenRequest>(endpoint, request);
-        return response;
+        return _client.PostAsync<CreateAccessTokenResponse, CreateAccessTokenRequest>(endpoint, request);
     }
 
-    public RestResponseBase SaferpayFieldsAccessTokenDeleteAccessToken(string accessToken)
-    {
-        if (_client == null) return default;
-        var data = SaferpayFieldsAccessTokenDeleteAccessTokenAsync(accessToken).GetAwaiter().GetResult();
-        return data;
-    }
+    public RestResponseBase SaferpayFieldsAccessTokenDeleteAccessToken(string accessToken) =>
+        SaferpayFieldsAccessTokenDeleteAccessTokenAsync(accessToken).GetAwaiter().GetResult();
 
-    public async Task<RestResponseBase> SaferpayFieldsAccessTokenDeleteAccessTokenAsync(string accessToken)
+    public Task<RestResponseBase> SaferpayFieldsAccessTokenDeleteAccessTokenAsync(string accessToken)
     {
-        if (_client == null) return default;
         var endpoint = $"rest/customers/{_client.CustomerId}/terminals/{_client.TerminalId}/fields-access-tokens/{accessToken}";
-
-        var response = await _client.DeleteAsync<RestResponseBase>(endpoint);
-        return response;
+        return _client.DeleteAsync<RestResponseBase>(endpoint);
     }
 
-    public CreateSingleUsePaymentLinkResponse SecurePayGateCreateSingleUsePaymentLink(CreateSingleUsePaymentLinkRequest request)
-    {
-        if (_client == null) return default;
-        var data = SecurePayGateCreateSingleUsePaymentLinkAsync(request).GetAwaiter().GetResult();
-        return data;
-    }
+    public CreateSingleUsePaymentLinkResponse SecurePayGateCreateSingleUsePaymentLink(CreateSingleUsePaymentLinkRequest request) =>
+        SecurePayGateCreateSingleUsePaymentLinkAsync(request).GetAwaiter().GetResult();
 
-    public async Task<CreateSingleUsePaymentLinkResponse> SecurePayGateCreateSingleUsePaymentLinkAsync(CreateSingleUsePaymentLinkRequest request)
+    public Task<CreateSingleUsePaymentLinkResponse> SecurePayGateCreateSingleUsePaymentLinkAsync(CreateSingleUsePaymentLinkRequest request)
     {
-        if (_client == null) return default;
         var endpoint = $"rest/customers/{_client.CustomerId}/terminals/{_client.TerminalId}/spg-offers";
-
-        var response = await _client.PostAsync<CreateSingleUsePaymentLinkResponse, CreateSingleUsePaymentLinkRequest>(endpoint, request);
-        return response;
+        return _client.PostAsync<CreateSingleUsePaymentLinkResponse, CreateSingleUsePaymentLinkRequest>(endpoint, request);
     }
 
-    public SingleUsePaymentLinkResponse SecurePayGateSingleUsePaymentLink(string offerId)
-    {
-        if (_client == null) return default;
-        var data = SecurePayGateSingleUsePaymentLinkAsync(offerId).GetAwaiter().GetResult();
-        return data;
-    }
+    public SingleUsePaymentLinkResponse SecurePayGateSingleUsePaymentLink(string offerId) =>
+        SecurePayGateSingleUsePaymentLinkAsync(offerId).GetAwaiter().GetResult();
 
-    public async Task<SingleUsePaymentLinkResponse> SecurePayGateSingleUsePaymentLinkAsync(string offerId)
+    public Task<SingleUsePaymentLinkResponse> SecurePayGateSingleUsePaymentLinkAsync(string offerId)
     {
-        if (_client == null) return default;
         var endpoint = $"rest/customers/{_client.CustomerId}/terminals/{_client.TerminalId}/spg-offers/{offerId}";
-        var response = await _client.GetAsync<SingleUsePaymentLinkResponse>(endpoint);
-        return response;
+        return _client.GetAsync<SingleUsePaymentLinkResponse>(endpoint);
     }
 
-    public TerminalResponse TerminalGetTerminal()
-    {
-        if (_client == null) return default;
-        var data = TerminalGetTerminalAsync().GetAwaiter().GetResult();
-        return data;
-    }
+    public TerminalResponse TerminalGetTerminal() =>
+        TerminalGetTerminalAsync().GetAwaiter().GetResult();
 
-    public async Task<TerminalResponse> TerminalGetTerminalAsync()
+    public Task<TerminalResponse> TerminalGetTerminalAsync()
     {
-        if (_client == null) return default;
         var endpoint = $"rest/customers/{_client.CustomerId}/terminals/{_client.TerminalId}";
-        var response = await _client.GetAsync<TerminalResponse>(endpoint);
-        return response;
+        return _client.GetAsync<TerminalResponse>(endpoint);
     }
 
-    public TerminalsResponse TerminalsGetTerminals()
-    {
-        if (_client == null) return default;
-        var data = TerminalsGetTerminalsAsync().GetAwaiter().GetResult();
-        return data;
-    }
+    public TerminalsResponse TerminalsGetTerminals() =>
+        TerminalsGetTerminalsAsync().GetAwaiter().GetResult();
 
-    public async Task<TerminalsResponse> TerminalsGetTerminalsAsync()
+    public Task<TerminalsResponse> TerminalsGetTerminalsAsync()
     {
-        if (_client == null) return default;
         var endpoint = $"rest/customers/{_client.CustomerId}/terminals";
-        var response = await _client.GetAsync<TerminalsResponse>(endpoint);
-        return response;
+        return _client.GetAsync<TerminalsResponse>(endpoint);
     }
 
-    public ReportingGetTransactionsResponse TransactionReportingGetTransactions(ReportingGetTransactionsRequest request)
-    {
-        if (_client == null) return default;
-        var data = TransactionReportingGetTransactionsAsync(request).GetAwaiter().GetResult();
-        return data;
-    }
+    public ReportingGetTransactionsResponse TransactionReportingGetTransactions(ReportingGetTransactionsRequest request) =>
+        TransactionReportingGetTransactionsAsync(request).GetAwaiter().GetResult();
 
-    public async Task<ReportingGetTransactionsResponse> TransactionReportingGetTransactionsAsync(ReportingGetTransactionsRequest request)
+    public Task<ReportingGetTransactionsResponse> TransactionReportingGetTransactionsAsync(ReportingGetTransactionsRequest request)
     {
-        if (_client == null) return default;
         var endpoint = $"rest/customers/{_client.CustomerId}/transactions";
-        var response = await _client.GetAsync<ReportingGetTransactionsResponse, ReportingGetTransactionsRequest>(endpoint, request);
-        return response;
+        return _client.GetAsync<ReportingGetTransactionsResponse, ReportingGetTransactionsRequest>(endpoint, request);
     }
 }

--- a/Channels/OmniChannel.cs
+++ b/Channels/OmniChannel.cs
@@ -1,4 +1,4 @@
-﻿using SaferPay.Config;
+using SaferPay.Config;
 using SaferPay.Interfaces;
 using SaferPay.Models.Core;
 using SaferPay.Models.OmniChannel;
@@ -14,31 +14,20 @@ public class OmniChannel : IOmniChannel
     private readonly ISaferPayClient _client;
 
     public OmniChannel(SaferPaySettings settings) => _client = new SaferPayClient(settings);
-    public OmniChannel(ISaferPayClient client) => _client = client;
-    public OmniChannel(string customerId, string terminalId, string userName, string passWord, bool sandBox = false) => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
+    public OmniChannel(ISaferPayClient client) => _client = client ?? throw new ArgumentNullException(nameof(client));
+    public OmniChannel(string customerId, string terminalId, string userName, string passWord, bool sandBox = false)
+        => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
 
 
-    public AcquireTransactionResponse AcquireTransaction(AcquireTransactionRequest request)
-    {
-        if (_client != null) return _client.Send<AcquireTransactionResponse, AcquireTransactionRequest>(SaferPayEndpoints.OmniChannelEndpoint + SaferPayMethods.OmniChannelAcquireTransaction, request);
-        return null;
-    }
+    public AcquireTransactionResponse AcquireTransaction(AcquireTransactionRequest request) =>
+        _client.Send<AcquireTransactionResponse, AcquireTransactionRequest>(SaferPayEndpoints.OmniChannelEndpoint + SaferPayMethods.OmniChannelAcquireTransaction, request);
 
-    public Task<AcquireTransactionResponse> AcquireTransactionAsync(AcquireTransactionRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AcquireTransactionResponse, AcquireTransactionRequest>(SaferPayEndpoints.OmniChannelEndpoint + SaferPayMethods.OmniChannelAcquireTransaction, request);
-        return null;
-    }
+    public Task<AcquireTransactionResponse> AcquireTransactionAsync(AcquireTransactionRequest request) =>
+        _client.SendAsync<AcquireTransactionResponse, AcquireTransactionRequest>(SaferPayEndpoints.OmniChannelEndpoint + SaferPayMethods.OmniChannelAcquireTransaction, request);
 
-    public InsertAliasResponse InsertAlias(InsertAliasRequest request)
-    {
-        if (_client != null) return _client.Send<InsertAliasResponse, InsertAliasRequest>(SaferPayEndpoints.OmniChannelEndpoint + SaferPayMethods.OmniChannelInsertAlias, request);
-        return null;
-    }
+    public InsertAliasResponse InsertAlias(InsertAliasRequest request) =>
+        _client.Send<InsertAliasResponse, InsertAliasRequest>(SaferPayEndpoints.OmniChannelEndpoint + SaferPayMethods.OmniChannelInsertAlias, request);
 
-    public Task<InsertAliasResponse> InsertAliasAsync(InsertAliasRequest request)
-    {
-        if (_client != null) return _client.SendAsync<InsertAliasResponse, InsertAliasRequest>(SaferPayEndpoints.OmniChannelEndpoint + SaferPayMethods.OmniChannelInsertAlias, request);
-        return null;
-    }
+    public Task<InsertAliasResponse> InsertAliasAsync(InsertAliasRequest request) =>
+        _client.SendAsync<InsertAliasResponse, InsertAliasRequest>(SaferPayEndpoints.OmniChannelEndpoint + SaferPayMethods.OmniChannelInsertAlias, request);
 }

--- a/Channels/PaymentPage.cs
+++ b/Channels/PaymentPage.cs
@@ -1,4 +1,4 @@
-﻿using SaferPay.Config;
+using SaferPay.Config;
 using SaferPay.Interfaces;
 using SaferPay.Models.Core;
 using SaferPay.Models.PaymentPage;
@@ -19,28 +19,29 @@ public class PaymentPage : IPaymentPage
 
     #region Ctors
     public PaymentPage(SaferPaySettings settings) => _client = new SaferPayClient(settings);
-    public PaymentPage(ISaferPayClient client) => _client = client;
-    public PaymentPage(string customerId, string terminalId, string userName, string passWord, bool sandBox = false) => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
+    public PaymentPage(ISaferPayClient client) => _client = client ?? throw new ArgumentNullException(nameof(client));
+    public PaymentPage(string customerId, string terminalId, string userName, string passWord, bool sandBox = false)
+        => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
     #endregion
 
     #region Methods
-    public AssertResponse Assert(AssertRequest request) => 
-        _client?.Send<AssertResponse, AssertRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageAssert, request);
+    public AssertResponse Assert(AssertRequest request) =>
+        _client.Send<AssertResponse, AssertRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageAssert, request);
 
     public AssertResponse Assert(string token) =>
-        _client?.Send<AssertResponse, AssertRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageAssert, new AssertRequest(token));
+        _client.Send<AssertResponse, AssertRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageAssert, new AssertRequest(token));
 
     public Task<AssertResponse> AssertAsync(AssertRequest request) =>
-        _client?.SendAsync<AssertResponse, AssertRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageAssert, request);
+        _client.SendAsync<AssertResponse, AssertRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageAssert, request);
 
     public Task<AssertResponse> AssertAsync(string token) =>
-        _client?.SendAsync<AssertResponse, AssertRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageAssert, new AssertRequest(token));
+        _client.SendAsync<AssertResponse, AssertRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageAssert, new AssertRequest(token));
 
     public InitializePaymentPageResponse Initialize(InitializePaymentPageRequest request) =>
-        _client?.Send<InitializePaymentPageResponse, InitializePaymentPageRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageInitialize, request);
+        _client.Send<InitializePaymentPageResponse, InitializePaymentPageRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageInitialize, request);
 
     public Task<InitializePaymentPageResponse> InitializeAsync(InitializePaymentPageRequest request) =>
-        _client?.SendAsync<InitializePaymentPageResponse, InitializePaymentPageRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageInitialize, request);
+        _client.SendAsync<InitializePaymentPageResponse, InitializePaymentPageRequest>(SaferPayEndpoints.PaymentPageEndpoint + SaferPayMethods.PaymentPageInitialize, request);
     #endregion
 
     public override string ToString() => base.ToString() ?? "Payment Page";

--- a/Channels/SecureCardData.cs
+++ b/Channels/SecureCardData.cs
@@ -1,4 +1,4 @@
-﻿using SaferPay.Config;
+using SaferPay.Config;
 using SaferPay.Interfaces;
 using SaferPay.Models.Core;
 using SaferPay.Models.SecureData;
@@ -10,78 +10,43 @@ public class SecureCardData : ISecureCardData
     private readonly ISaferPayClient _client;
 
     public SecureCardData(SaferPaySettings settings) => _client = new SaferPayClient(settings);
-    public SecureCardData(ISaferPayClient client) => _client = client;
-    public SecureCardData(string customerId, string terminalId, string userName, string passWord, bool sandBox = false) => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
+    public SecureCardData(ISaferPayClient client) => _client = client ?? throw new ArgumentNullException(nameof(client));
+    public SecureCardData(string customerId, string terminalId, string userName, string passWord, bool sandBox = false)
+        => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
 
-    public AliasDeleteResponse AliasDelete(AliasDeleteRequest request)
-    {
-        if (_client != null) return _client.Send<AliasDeleteResponse, AliasDeleteRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasDelete, request);
-        return null;
-    }
+    public AliasDeleteResponse AliasDelete(AliasDeleteRequest request) =>
+        _client.Send<AliasDeleteResponse, AliasDeleteRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasDelete, request);
 
-    public Task<AliasDeleteResponse> AliasDeleteAsync(AliasDeleteRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AliasDeleteResponse, AliasDeleteRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasDelete, request);
-        return null;
-    }
+    public Task<AliasDeleteResponse> AliasDeleteAsync(AliasDeleteRequest request) =>
+        _client.SendAsync<AliasDeleteResponse, AliasDeleteRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasDelete, request);
 
-    public AliasInquireResponse AliasInquire(AliasInquireRequest request)
-    {
-        if (_client != null) return _client.Send<AliasInquireResponse, AliasInquireRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInquire, request);
-        return null;
-    }
+    public AliasInquireResponse AliasInquire(AliasInquireRequest request) =>
+        _client.Send<AliasInquireResponse, AliasInquireRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInquire, request);
 
-    public Task<AliasInquireResponse> AliasInquireAsync(AliasInquireRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AliasInquireResponse, AliasInquireRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInquire, request);
-        return null;
-    }
+    public Task<AliasInquireResponse> AliasInquireAsync(AliasInquireRequest request) =>
+        _client.SendAsync<AliasInquireResponse, AliasInquireRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInquire, request);
 
-    public AliasInsertResponse AliasInsert(AliasInsertRequest request)
-    {
-        if (_client != null) return _client.Send<AliasInsertResponse, AliasInsertRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInsert, request);
-        return null;
-    }
+    public AliasInsertResponse AliasInsert(AliasInsertRequest request) =>
+        _client.Send<AliasInsertResponse, AliasInsertRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInsert, request);
 
-    public Task<AliasInsertResponse> AliasInsertAsync(AliasInsertRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AliasInsertResponse, AliasInsertRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInsert, request);
-        return null;
-    }
+    public Task<AliasInsertResponse> AliasInsertAsync(AliasInsertRequest request) =>
+        _client.SendAsync<AliasInsertResponse, AliasInsertRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInsert, request);
 
-    public AliasUpdateResponse AliasUpdate(AliasUpdateRequest request)
-    {
-        if (_client != null) return _client.Send<AliasUpdateResponse, AliasUpdateRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasUpdate, request);
-        return null;
-    }
+    public AliasUpdateResponse AliasUpdate(AliasUpdateRequest request) =>
+        _client.Send<AliasUpdateResponse, AliasUpdateRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasUpdate, request);
 
-    public Task<AliasUpdateResponse> AliasUpdateAsync(AliasUpdateRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AliasUpdateResponse, AliasUpdateRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasUpdate, request);
-        return null;
-    }
+    public Task<AliasUpdateResponse> AliasUpdateAsync(AliasUpdateRequest request) =>
+        _client.SendAsync<AliasUpdateResponse, AliasUpdateRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasUpdate, request);
 
-    public AssertInsertResponse AssertInsert(AssertInsertRequest request)
-    {
-        if (_client != null) return _client.Send<AssertInsertResponse, AssertInsertRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasAssertInsert, request);
-        return null;
-    }
+    public AssertInsertResponse AssertInsert(AssertInsertRequest request) =>
+        _client.Send<AssertInsertResponse, AssertInsertRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasAssertInsert, request);
 
-    public Task<AssertInsertResponse> AssertInsertAsync(AssertInsertRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AssertInsertResponse, AssertInsertRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasAssertInsert, request);
-        return null;
-    }
+    public Task<AssertInsertResponse> AssertInsertAsync(AssertInsertRequest request) =>
+        _client.SendAsync<AssertInsertResponse, AssertInsertRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasAssertInsert, request);
 
-    public InsertDirectResponse InsertDirect(InsertDirectRequest request)
-    {
-        if (_client != null) return _client.Send<InsertDirectResponse, InsertDirectRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInsertDirect, request);
-        return null;
-    }
+    public InsertDirectResponse InsertDirect(InsertDirectRequest request) =>
+        _client.Send<InsertDirectResponse, InsertDirectRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInsertDirect, request);
 
-    public Task<InsertDirectResponse> InsertDirectAsync(InsertDirectRequest request)
-    {
-        if (_client != null) return _client.SendAsync<InsertDirectResponse, InsertDirectRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInsertDirect, request);
-        return null;
-    }
+    public Task<InsertDirectResponse> InsertDirectAsync(InsertDirectRequest request) =>
+        _client.SendAsync<InsertDirectResponse, InsertDirectRequest>(SaferPayEndpoints.AliasEndpoint + SaferPayMethods.AliasInsertDirect, request);
 }

--- a/Channels/Transaction.cs
+++ b/Channels/Transaction.cs
@@ -1,4 +1,4 @@
-﻿using SaferPay.Config;
+using SaferPay.Config;
 using SaferPay.Interfaces;
 using SaferPay.Models.Core;
 using SaferPay.Models.Transaction;
@@ -11,263 +11,156 @@ public class Transaction : ITransaction
     private readonly ISaferPayClient _client;
 
     public Transaction(SaferPaySettings settings) => _client = new SaferPayClient(settings);
-    public Transaction(ISaferPayClient client) => _client = client;
-    public Transaction(string customerId, string terminalId, string userName, string passWord, bool sandBox = false) => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
+    public Transaction(ISaferPayClient client) => _client = client ?? throw new ArgumentNullException(nameof(client));
+    public Transaction(string customerId, string terminalId, string userName, string passWord, bool sandBox = false)
+        => _client = new SaferPayClient(new SaferPaySettings(customerId, terminalId, userName, passWord, sandBox));
 
     #region Initialize
-    public InitializeResponse Initialize(InitializeRequest request)
-    {
-        if (_client != null) return _client.Send<InitializeResponse, InitializeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionInitialize, request);
-        return null;
-    }
+    public InitializeResponse Initialize(InitializeRequest request) =>
+        _client.Send<InitializeResponse, InitializeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionInitialize, request);
 
-    public Task<InitializeResponse> InitializeAsync(InitializeRequest request)
-    {
-        if (_client != null) return _client.SendAsync<InitializeResponse, InitializeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionInitialize, request);
-        return null;
-    }
+    public Task<InitializeResponse> InitializeAsync(InitializeRequest request) =>
+        _client.SendAsync<InitializeResponse, InitializeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionInitialize, request);
     #endregion
 
-    #region Authorize 
-    public AuthorizeResponse Authorize(AuthorizeRequest request)
-    {
-        if (_client != null) return _client.Send<AuthorizeResponse, AuthorizeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorize, request);
-        return null;
-    }
+    #region Authorize
+    public AuthorizeResponse Authorize(AuthorizeRequest request) =>
+        _client.Send<AuthorizeResponse, AuthorizeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorize, request);
 
-    public Task<AuthorizeResponse> AuthorizeAsync(AuthorizeRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AuthorizeResponse, AuthorizeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorize, request);
-        return null;
-    }
+    public Task<AuthorizeResponse> AuthorizeAsync(AuthorizeRequest request) =>
+        _client.SendAsync<AuthorizeResponse, AuthorizeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorize, request);
     #endregion
 
-    #region AuthorizeDirect 
-    public AuthorizeDirectResponse AuthorizeDirect(AuthorizeDirectRequest request)
-    {
-        if (_client != null) return _client.Send<AuthorizeDirectResponse, AuthorizeDirectRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorizeDirect, request);
-        return null;
-    }
+    #region AuthorizeDirect
+    public AuthorizeDirectResponse AuthorizeDirect(AuthorizeDirectRequest request) =>
+        _client.Send<AuthorizeDirectResponse, AuthorizeDirectRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorizeDirect, request);
 
-    public Task<AuthorizeDirectResponse> AuthorizeDirectAsync(AuthorizeDirectRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AuthorizeDirectResponse, AuthorizeDirectRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorizeDirect, request);
-        return null;
-    }
+    public Task<AuthorizeDirectResponse> AuthorizeDirectAsync(AuthorizeDirectRequest request) =>
+        _client.SendAsync<AuthorizeDirectResponse, AuthorizeDirectRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorizeDirect, request);
     #endregion
 
-    #region AuthorizeReferenced 
-    public AuthorizeReferencedResponse AuthorizeReferenced(AuthorizeReferencedRequest request)
-    {
-        if (_client != null) return _client.Send<AuthorizeReferencedResponse, AuthorizeReferencedRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorizeReferenced, request);
-        return null;
-    }
+    #region AuthorizeReferenced
+    public AuthorizeReferencedResponse AuthorizeReferenced(AuthorizeReferencedRequest request) =>
+        _client.Send<AuthorizeReferencedResponse, AuthorizeReferencedRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorizeReferenced, request);
 
-    public Task<AuthorizeReferencedResponse> AuthorizeReferencedAsync(AuthorizeReferencedRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AuthorizeReferencedResponse, AuthorizeReferencedRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorizeReferenced, request);
-        return null;
-    }
+    public Task<AuthorizeReferencedResponse> AuthorizeReferencedAsync(AuthorizeReferencedRequest request) =>
+        _client.SendAsync<AuthorizeReferencedResponse, AuthorizeReferencedRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAuthorizeReferenced, request);
     #endregion
 
     #region Capture
-    public CaptureResponse Capture(CaptureRequest request)
-    {
-        if (_client != null) return _client.Send<CaptureResponse, CaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionCapture, request);
-        return null;
-    }
+    public CaptureResponse Capture(CaptureRequest request) =>
+        _client.Send<CaptureResponse, CaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionCapture, request);
 
-    public Task<CaptureResponse> CaptureAsync(CaptureRequest request)
-    {
-        if (_client != null) return _client.SendAsync<CaptureResponse, CaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionCapture, request);
-        return null;
-    }
+    public Task<CaptureResponse> CaptureAsync(CaptureRequest request) =>
+        _client.SendAsync<CaptureResponse, CaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionCapture, request);
     #endregion
 
-    #region MultipartCapture 
-    public MultipartCaptureResponse MultipartCapture(MultipartCaptureRequest request)
-    {
-        if (_client != null) return _client.Send<MultipartCaptureResponse, MultipartCaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionMultipartCapture, request);
-        return null;
-    }
+    #region MultipartCapture
+    public MultipartCaptureResponse MultipartCapture(MultipartCaptureRequest request) =>
+        _client.Send<MultipartCaptureResponse, MultipartCaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionMultipartCapture, request);
 
-    public Task<MultipartCaptureResponse> MultipartCaptureAsync(MultipartCaptureRequest request)
-    {
-        if (_client != null) return _client.SendAsync<MultipartCaptureResponse, MultipartCaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionMultipartCapture, request);
-        return null;
-    }
+    public Task<MultipartCaptureResponse> MultipartCaptureAsync(MultipartCaptureRequest request) =>
+        _client.SendAsync<MultipartCaptureResponse, MultipartCaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionMultipartCapture, request);
     #endregion
 
-    #region AssertCapture 
-    public AssertCaptureResponse AssertCapture(AssertCaptureRequest request)
-    {
-        if (_client != null) return _client.Send<AssertCaptureResponse, AssertCaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertCapture, request);
-        return null;
-    }
+    #region AssertCapture
+    public AssertCaptureResponse AssertCapture(AssertCaptureRequest request) =>
+        _client.Send<AssertCaptureResponse, AssertCaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertCapture, request);
 
-    public Task<AssertCaptureResponse> AssertCaptureAsync(AssertCaptureRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AssertCaptureResponse, AssertCaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertCapture, request);
-        return null;
-    }
+    public Task<AssertCaptureResponse> AssertCaptureAsync(AssertCaptureRequest request) =>
+        _client.SendAsync<AssertCaptureResponse, AssertCaptureRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertCapture, request);
     #endregion
 
-    #region MultipartFinalize 
-    public MultipartFinalizeResponse MultipartFinalize(MultipartFinalizeRequest request)
-    {
-        if (_client != null) return _client.Send<MultipartFinalizeResponse, MultipartFinalizeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionMultipartFinalize, request);
-        return null;
-    }
+    #region MultipartFinalize
+    public MultipartFinalizeResponse MultipartFinalize(MultipartFinalizeRequest request) =>
+        _client.Send<MultipartFinalizeResponse, MultipartFinalizeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionMultipartFinalize, request);
 
-    public Task<MultipartFinalizeResponse> MultipartFinalizeAsync(MultipartFinalizeRequest request)
-    {
-        if (_client != null) return _client.SendAsync<MultipartFinalizeResponse, MultipartFinalizeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionMultipartFinalize, request);
-        return null;
-    }
+    public Task<MultipartFinalizeResponse> MultipartFinalizeAsync(MultipartFinalizeRequest request) =>
+        _client.SendAsync<MultipartFinalizeResponse, MultipartFinalizeRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionMultipartFinalize, request);
     #endregion
 
-    #region Refund 
-    public RefundResponse Refund(RefundRequest request)
-    {
-        if (_client != null) return _client.Send<RefundResponse, RefundRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRefund, request);
-        return null;
-    }
+    #region Refund
+    public RefundResponse Refund(RefundRequest request) =>
+        _client.Send<RefundResponse, RefundRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRefund, request);
 
-    public Task<RefundResponse> RefundAsync(RefundRequest request)
-    {
-        if (_client != null) return _client.SendAsync<RefundResponse, RefundRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRefund, request);
-        return null;
-    }
+    public Task<RefundResponse> RefundAsync(RefundRequest request) =>
+        _client.SendAsync<RefundResponse, RefundRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRefund, request);
     #endregion
 
-    #region AssertRefund 
-    public AssertRefundResponse AssertRefund(AssertRefundRequest request)
-    {
-        if (_client != null) return _client.Send<AssertRefundResponse, AssertRefundRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertRefund, request);
-        return null;
-    }
+    #region AssertRefund
+    public AssertRefundResponse AssertRefund(AssertRefundRequest request) =>
+        _client.Send<AssertRefundResponse, AssertRefundRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertRefund, request);
 
-    public Task<AssertRefundResponse> AssertRefundAsync(AssertRefundRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AssertRefundResponse, AssertRefundRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertRefund, request);
-        return null;
-    }
+    public Task<AssertRefundResponse> AssertRefundAsync(AssertRefundRequest request) =>
+        _client.SendAsync<AssertRefundResponse, AssertRefundRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertRefund, request);
     #endregion
 
-    #region RefundDirect 
-    public RefundDirectResponse RefundDirect(RefundDirectRequest request)
-    {
-        if (_client != null) return _client.Send<RefundDirectResponse, RefundDirectRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRefundDirect, request);
-        return null;
-    }
+    #region RefundDirect
+    public RefundDirectResponse RefundDirect(RefundDirectRequest request) =>
+        _client.Send<RefundDirectResponse, RefundDirectRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRefundDirect, request);
 
-    public Task<RefundDirectResponse> RefundDirectAsync(RefundDirectRequest request)
-    {
-        if (_client != null) return _client.SendAsync<RefundDirectResponse, RefundDirectRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRefundDirect, request);
-        return null;
-    }
+    public Task<RefundDirectResponse> RefundDirectAsync(RefundDirectRequest request) =>
+        _client.SendAsync<RefundDirectResponse, RefundDirectRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRefundDirect, request);
     #endregion
 
     #region Cancel
-    public CancelResponse Cancel(CancelRequest request)
-    {
-        if (_client != null) return _client.Send<CancelResponse, CancelRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionCancel, request);
-        return null;
-    }
+    public CancelResponse Cancel(CancelRequest request) =>
+        _client.Send<CancelResponse, CancelRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionCancel, request);
 
-    public Task<CancelResponse> CancelAsync(CancelRequest request)
-    {
-        if (_client != null) return _client.SendAsync<CancelResponse, CancelRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionCancel, request);
-        return null;
-    }
+    public Task<CancelResponse> CancelAsync(CancelRequest request) =>
+        _client.SendAsync<CancelResponse, CancelRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionCancel, request);
     #endregion
 
-    #region RedirectPayment 
+    #region RedirectPayment
     [Obsolete("This feature is deprecated and replaced by the Payment Page. Please use the parameter PaymentMethods to directly select the desired 3rd party provider!")]
-    public RedirectPaymentResponse RedirectPayment(RedirectPaymentRequest request)
-    {
-        if (_client != null) return _client.Send<RedirectPaymentResponse, RedirectPaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRedirectPayment, request);
-        return null;
-    }
+    public RedirectPaymentResponse RedirectPayment(RedirectPaymentRequest request) =>
+        _client.Send<RedirectPaymentResponse, RedirectPaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRedirectPayment, request);
 
     [Obsolete("This feature is deprecated and replaced by the Payment Page. Please use the parameter PaymentMethods to directly select the desired 3rd party provider!")]
-    public Task<RedirectPaymentResponse> RedirectPaymentAsync(RedirectPaymentRequest request)
-    {
-        if (_client != null) return _client.SendAsync<RedirectPaymentResponse, RedirectPaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRedirectPayment, request);
-        return null;
-    }
+    public Task<RedirectPaymentResponse> RedirectPaymentAsync(RedirectPaymentRequest request) =>
+        _client.SendAsync<RedirectPaymentResponse, RedirectPaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionRedirectPayment, request);
     #endregion
 
-    #region AssertRedirectPayment 
+    #region AssertRedirectPayment
     [Obsolete("This feature is deprecated and replaced by the Payment Page. Please use the parameter PaymentMethods to directly select the desired 3rd party provider!")]
-    public AssertRedirectPaymentResponse AssertRedirectPayment(AssertRedirectPaymentRequest request)
-    {
-        if (_client != null) return _client.Send<AssertRedirectPaymentResponse, AssertRedirectPaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertRedirectPayment, request);
-        return null;
-    }
+    public AssertRedirectPaymentResponse AssertRedirectPayment(AssertRedirectPaymentRequest request) =>
+        _client.Send<AssertRedirectPaymentResponse, AssertRedirectPaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertRedirectPayment, request);
 
     [Obsolete("This feature is deprecated and replaced by the Payment Page. Please use the parameter PaymentMethods to directly select the desired 3rd party provider!")]
-    public Task<AssertRedirectPaymentResponse> AssertRedirectPaymentAsync(AssertRedirectPaymentRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AssertRedirectPaymentResponse, AssertRedirectPaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertRedirectPayment, request);
-        return null;
-    }
+    public Task<AssertRedirectPaymentResponse> AssertRedirectPaymentAsync(AssertRedirectPaymentRequest request) =>
+        _client.SendAsync<AssertRedirectPaymentResponse, AssertRedirectPaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAssertRedirectPayment, request);
     #endregion
 
-    #region Inquire 
-    public InquireResponse Inquire(InquireRequest request)
-    {
-        if (_client != null) return _client.Send<InquireResponse, InquireRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionInquire, request);
-        return null;
-    }
+    #region Inquire
+    public InquireResponse Inquire(InquireRequest request) =>
+        _client.Send<InquireResponse, InquireRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionInquire, request);
 
-    public Task<InquireResponse> InquireAsync(InquireRequest request)
-    {
-        if (_client != null) return _client.SendAsync<InquireResponse, InquireRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionInquire, request);
-        return null;
-    }
+    public Task<InquireResponse> InquireAsync(InquireRequest request) =>
+        _client.SendAsync<InquireResponse, InquireRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionInquire, request);
     #endregion
 
-    #region AlternativePayment 
-    public AlternativePaymentResponse AlternativePayment(AlternativePaymentRequest request)
-    {
-        if (_client != null) return _client.Send<AlternativePaymentResponse, AlternativePaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAlternativePayment, request);
-        return null;
-    }
+    #region AlternativePayment
+    public AlternativePaymentResponse AlternativePayment(AlternativePaymentRequest request) =>
+        _client.Send<AlternativePaymentResponse, AlternativePaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAlternativePayment, request);
 
-    public Task<AlternativePaymentResponse> AlternativePaymentAsync(AlternativePaymentRequest request)
-    {
-        if (_client != null) return _client.SendAsync<AlternativePaymentResponse, AlternativePaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAlternativePayment, request);
-        return null;
-    }
+    public Task<AlternativePaymentResponse> AlternativePaymentAsync(AlternativePaymentRequest request) =>
+        _client.SendAsync<AlternativePaymentResponse, AlternativePaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionAlternativePayment, request);
     #endregion
 
-    #region QueryAlternativePayment 
-    public QueryAlternativePaymentResponse QueryAlternativePayment(QueryAlternativePaymentRequest request)
-    {
-        if (_client != null) return _client.Send<QueryAlternativePaymentResponse, QueryAlternativePaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionQueryAlternativePayment, request);
-        return null;
-    }
+    #region QueryAlternativePayment
+    public QueryAlternativePaymentResponse QueryAlternativePayment(QueryAlternativePaymentRequest request) =>
+        _client.Send<QueryAlternativePaymentResponse, QueryAlternativePaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionQueryAlternativePayment, request);
 
-    public Task<QueryAlternativePaymentResponse> QueryAlternativePaymentAsync(QueryAlternativePaymentRequest request)
-    {
-        if (_client != null) return _client.SendAsync<QueryAlternativePaymentResponse, QueryAlternativePaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionQueryAlternativePayment, request);
-        return null;
-    }
+    public Task<QueryAlternativePaymentResponse> QueryAlternativePaymentAsync(QueryAlternativePaymentRequest request) =>
+        _client.SendAsync<QueryAlternativePaymentResponse, QueryAlternativePaymentRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionQueryAlternativePayment, request);
     #endregion
 
     #region DccInquiry
-    public DccInquiryResponse DccInquire(DccInquiryRequest request)
-    {
-        if (_client != null) return _client.Send<DccInquiryResponse, DccInquiryRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionDccInquiry, request);
-        return null;
-    }
+    public DccInquiryResponse DccInquire(DccInquiryRequest request) =>
+        _client.Send<DccInquiryResponse, DccInquiryRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionDccInquiry, request);
 
-    public Task<DccInquiryResponse> DccInquiryAsync(DccInquiryRequest request)
-    {
-        if (_client != null) return _client.SendAsync<DccInquiryResponse, DccInquiryRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionDccInquiry, request);
-        return null;
-    }
+    public Task<DccInquiryResponse> DccInquiryAsync(DccInquiryRequest request) =>
+        _client.SendAsync<DccInquiryResponse, DccInquiryRequest>(SaferPayEndpoints.TransactionEndpoint + SaferPayMethods.TransactionDccInquiry, request);
     #endregion
 
 }

--- a/Helpers/JsonHelpers.cs
+++ b/Helpers/JsonHelpers.cs
@@ -1,4 +1,0 @@
-﻿namespace SaferPay.Helpers
-{
-
-}

--- a/SaferPay.csproj
+++ b/SaferPay.csproj
@@ -35,7 +35,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Compile Remove="Helpers\JsonHelpers.cs" />
 		<Compile Remove="Models\Core\InitializationCard.cs" />
 		<Compile Remove="Models\Core\InitializationPaymentMeans.cs" />
 		<Compile Remove="Models\Core\InitializationResponseRedirect.cs" />

--- a/SaferPayClient.cs
+++ b/SaferPayClient.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using RestSharp;
 using RestSharp.Authenticators;
 using SaferPay.Config;
@@ -65,6 +65,23 @@ public class SaferPayClient : ISaferPayClient
         RetryIndicator = 0
     };
 
+    private RestClient BuildClient(Uri uri)
+    {
+        var opt = new RestClientOptions(uri)
+        {
+            Authenticator = new HttpBasicAuthenticator(_settings.Username, _settings.Password)
+        };
+        return new RestClient(opt);
+    }
+
+    private static void AddManagementHeaders(RestRequest req)
+    {
+        req.AddHeader("Saferpay-ApiVersion", SaferPayApiConstants.Version);
+        req.AddHeader("Saferpay-RequestId", Guid.NewGuid().ToString());
+        req.AddHeader("Content-Type", "application/json; charset=utf-8");
+        req.AddHeader("Accept", "application/json");
+    }
+
     /// <summary>
     /// Send Async Method
     /// </summary>
@@ -76,19 +93,14 @@ public class SaferPayClient : ISaferPayClient
     /// <exception cref="ArgumentNullException"></exception>
     public virtual async Task<TResponse> SendAsync<TResponse, TRequest>(string path, TRequest request) where TRequest : RequestBase where TResponse : ResponseBase
     {
-
         try
         {
             if (request == null) throw new ArgumentNullException(nameof(request));
             request.RequestHeader = CreateRequestHeader();
             var uri = new Uri(_settings.BaseUri, path);
 
-            var opt = new RestClientOptions(uri);
-            opt.Authenticator = new HttpBasicAuthenticator(_settings.Username, _settings.Password);
-
-            using var client = new RestClient(opt);
-            var req = new RestRequest();
-            req.Method = Method.Post;
+            using var client = BuildClient(uri);
+            var req = new RestRequest { Method = Method.Post };
 
             var json = request.Json();
             req.AddParameter("application/json", json, ParameterType.RequestBody);
@@ -100,55 +112,14 @@ public class SaferPayClient : ISaferPayClient
                 response!.ResponseStatus = Enums.ResponseStatus.SUCCESS;
                 return response;
             }
-            else
-            {
-                var errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(res.Content, _jsonSerializerSettings);
 
-                if (!_settings.ThrowExceptionOnFail)
-                {
-                    var response = Activator.CreateInstance<TResponse>();
-                    response.Error = errorResponse;
-                    response.ResponseStatus = Enums.ResponseStatus.ERROR;
-                    return response;
-                }
-
-                throw new SaferPayException(res.StatusCode, errorResponse);
-            }
-        }
-
-        catch (SaferPayException spex)
-        {
-            if (!_settings.ThrowExceptionOnFail)
-            {
-                var response = Activator.CreateInstance<TResponse>();
-                response.Error = new ErrorResponse();
-                response.Error.ErrorMessage = spex.Message.ToString();
-                response.ResponseStatus = Enums.ResponseStatus.ERROR;
-                return response;
-            }
-
-            if (_settings.ThrowExceptionOnFail)
-            {
-                throw;
-            }
+            return HandleSendErrorResponse<TResponse>(res);
         }
         catch (Exception ex)
         {
-
-            if (!_settings.ThrowExceptionOnFail)
-            {
-                var response = Activator.CreateInstance<TResponse>();
-                response.Error = new ErrorResponse();
-                response.Error.ErrorMessage = ex.Message.ToString();
-                response.ResponseStatus = Enums.ResponseStatus.ERROR;
-                return response;
-            }
-
-            throw;
-
+            if (_settings.ThrowExceptionOnFail) throw;
+            return ProcessSendFailure<TResponse>(default, new ErrorResponse { ErrorMessage = ex.Message });
         }
-
-        return null;
     }
 
     public void Dispose()
@@ -172,12 +143,8 @@ public class SaferPayClient : ISaferPayClient
         request.RequestHeader = CreateRequestHeader();
         var uri = new Uri(_settings.BaseUri, path);
 
-        var opt = new RestClientOptions(uri);
-        opt.Authenticator = new HttpBasicAuthenticator(_settings.Username, _settings.Password);
-
-        using var client = new RestClient(opt);
-        var req = new RestRequest();
-        req.Method = Method.Post;
+        using var client = BuildClient(uri);
+        var req = new RestRequest { Method = Method.Post };
 
         var json = request.Json();
         req.AddParameter("application/json", json, ParameterType.RequestBody);
@@ -189,48 +156,25 @@ public class SaferPayClient : ISaferPayClient
             response!.ResponseStatus = Enums.ResponseStatus.SUCCESS;
             return response;
         }
-        else
-        {
-            var errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(res.Content, _jsonSerializerSettings);
 
-            if (!_settings.ThrowExceptionOnFail)
-            {
-                var response = Activator.CreateInstance<TResponse>();
-                response.Error = errorResponse;
-                response.ResponseStatus = Enums.ResponseStatus.ERROR;
-                return response;
-            }
-
-            throw new SaferPayException(res.StatusCode, errorResponse);
-        }
+        return HandleSendErrorResponse<TResponse>(res);
     }
 
     public TResponse Get<TResponse>(string path) where TResponse : Models.Management.RestResponseBase
     {
-        var response = GetAsync<TResponse>(path).GetAwaiter().GetResult();
-        return response;
+        return GetAsync<TResponse>(path).GetAwaiter().GetResult();
     }
 
     public async Task<TResponse> GetAsync<TResponse>(string path) where TResponse : Models.Management.RestResponseBase
     {
         var uri = new Uri(_settings.BaseUri, path);
-        var opt = new RestClientOptions(uri);
+        using var client = BuildClient(uri);
 
-        opt.Authenticator = new HttpBasicAuthenticator(_settings.Username, _settings.Password);
-        using var client = new RestClient(opt);
-
-        var req = new RestRequest();
-        req.Method = Method.Get;
-
-        req.AddHeader("Saferpay-ApiVersion", SaferPayApiConstants.Version);
-        req.AddHeader("Saferpay-RequestId", Guid.NewGuid().ToString());
-
-        req.AddHeader("Content-Type", "application/json; charset=utf-8");
-        req.AddHeader("Accept", "application/json");
+        var req = new RestRequest { Method = Method.Get };
+        AddManagementHeaders(req);
 
         var res = await client.ExecuteAsync(req);
 
-        // 200 OK
         if (res.IsSuccessful && res.StatusCode == System.Net.HttpStatusCode.OK)
         {
             var response = JsonConvert.DeserializeObject<TResponse>(res.Content ?? "{}", _jsonSerializerSettings);
@@ -241,111 +185,59 @@ public class SaferPayClient : ISaferPayClient
             }
         }
 
-        // 404 Not Found
-        if (res.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            var notFoundError = new ErrorResponse { ErrorMessage = "Requested resource not found (404)." };
-
-            if (!_settings.ThrowExceptionOnFail)
-            {
-                var response = Activator.CreateInstance<TResponse>();
-                response.Error = notFoundError;
-                response.ResponseStatus = Enums.ResponseStatus.ERROR;
-                return response;
-            }
-            throw new SaferPayException(res.StatusCode, notFoundError);
-        }
-
-        // Other Errors (400, 401, 500 vb.)
-        ErrorResponse errorResponse = null;
-        if (!string.IsNullOrEmpty(res.Content))
-        {
-            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(res.Content, _jsonSerializerSettings);
-        }
-
-        errorResponse ??= new ErrorResponse { ErrorMessage = res.ErrorMessage ?? "Unknown API Error" };
-
-        if (!_settings.ThrowExceptionOnFail)
-        {
-            var response = Activator.CreateInstance<TResponse>();
-            response.Error = errorResponse;
-            response.ResponseStatus = Enums.ResponseStatus.ERROR;
-            return response;
-        }
-
-        throw new SaferPayException(res.StatusCode, errorResponse);
-
+        return HandleErrorResponse<TResponse>(res);
     }
 
     public TResponse Get<TResponse, TRequest>(string path, TRequest request)
         where TResponse : Models.Management.RestResponseBase
         where TRequest : RestRequestBase
     {
-        var response = GetAsync<TResponse, TRequest>(path, request).GetAwaiter().GetResult();
-        return response;
+        return GetAsync<TResponse, TRequest>(path, request).GetAwaiter().GetResult();
     }
 
     public async Task<TResponse> GetAsync<TResponse, TRequest>(string path, TRequest request)
         where TResponse : Models.Management.RestResponseBase
         where TRequest : RestRequestBase
     {
-        var opt = new RestClientOptions(_settings.BaseUri);
-
-        opt.Authenticator = new HttpBasicAuthenticator(_settings.Username, _settings.Password);
-        using var client = new RestClient(opt);
+        using var client = BuildClient(_settings.BaseUri);
 
         var req = new RestRequest(path, Method.Get);
 
-        // 1. Query Parametrelerini Otomatik Ekleme
+        // Query parameters
         if (request != null)
         {
-            // 1. Nesnenin tüm property'lerini alıyoruz
             var properties = typeof(TRequest).GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
             foreach (var prop in properties)
             {
-                // 2. [JsonIgnore] varsa bu property'yi tamamen atla
                 if (Attribute.IsDefined(prop, typeof(JsonIgnoreAttribute)))
                     continue;
 
-                // 3. [JsonProperty] niteliğini al
                 var jsonProperty = prop.GetCustomAttribute<JsonPropertyAttribute>();
-
-                // Eğer JsonProperty atanmamışsa standart ismini kullan, atanmışsa oradaki ismi kullan
                 string paramName = jsonProperty != null ? jsonProperty.PropertyName : prop.Name;
 
                 var value = prop.GetValue(request);
+                if (value == null) continue;
 
-                // 4. Sadece null olmayan değerleri ekle
-                if (value != null)
+                if (prop.PropertyType.IsEnum || (Nullable.GetUnderlyingType(prop.PropertyType)?.IsEnum == true))
                 {
-                    // Değer bir Enum ise, string karşılığını (USD, TRY vb.) gönder
-                    if (prop.PropertyType.IsEnum || (Nullable.GetUnderlyingType(prop.PropertyType)?.IsEnum == true))
-                    {
-                        req.AddQueryParameter(paramName, value.ToString());
-                    }
-                    // DateTime kontrolü (Eğer unutup JsonIgnore koymazsanız patlamasın diye)
-                    else if (value is DateTime dt)
-                    {
-                        req.AddQueryParameter(paramName, dt.ToString("yyyy-MM-ddTHH:mm"));
-                    }
-                    else
-                    {
-                        req.AddQueryParameter(paramName, value.ToString());
-                    }
+                    req.AddQueryParameter(paramName, value.ToString());
+                }
+                else if (value is DateTime dt)
+                {
+                    req.AddQueryParameter(paramName, dt.ToString("yyyy-MM-ddTHH:mm"));
+                }
+                else
+                {
+                    req.AddQueryParameter(paramName, value.ToString());
                 }
             }
         }
 
-        // 2. Zorunlu Saferpay Header'ları
-        req.AddHeader("Saferpay-ApiVersion", SaferPayApiConstants.Version);
-        req.AddHeader("Saferpay-RequestId", Guid.NewGuid().ToString());
-        req.AddHeader("Accept", "application/json");
-        req.AddHeader("Content-Type", "application/json; charset=utf-8");
+        AddManagementHeaders(req);
 
         var res = await client.ExecuteAsync(req);
 
-        // 3. Başarı Kontrolü (200 OK)
         if (res.IsSuccessful && res.StatusCode == System.Net.HttpStatusCode.OK)
         {
             var response = JsonConvert.DeserializeObject<TResponse>(res.Content ?? "{}", _jsonSerializerSettings);
@@ -356,67 +248,24 @@ public class SaferPayClient : ISaferPayClient
             }
         }
 
-        // 404 Not Found
-        if (res.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            var notFoundError = new ErrorResponse { ErrorMessage = "Requested resource not found (404)." };
-
-            if (!_settings.ThrowExceptionOnFail)
-            {
-                var response = Activator.CreateInstance<TResponse>();
-                response.Error = notFoundError;
-                response.ResponseStatus = Enums.ResponseStatus.ERROR;
-                return response;
-            }
-            throw new SaferPayException(res.StatusCode, notFoundError);
-        }
-
-        // Other Errors (400, 401, 500 vb.)
-        ErrorResponse errorResponse = null;
-        if (!string.IsNullOrEmpty(res.Content))
-        {
-            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(res.Content, _jsonSerializerSettings);
-        }
-
-        errorResponse ??= new ErrorResponse { ErrorMessage = res.ErrorMessage ?? "Unknown API Error" };
-
-        if (!_settings.ThrowExceptionOnFail)
-        {
-            var response = Activator.CreateInstance<TResponse>();
-            response.Error = errorResponse;
-            response.ResponseStatus = Enums.ResponseStatus.ERROR;
-            return response;
-        }
-
-        throw new SaferPayException(res.StatusCode, errorResponse);
+        return HandleErrorResponse<TResponse>(res);
     }
 
     public TResponse Post<TResponse>(string path) where TResponse : Models.Management.RestResponseBase
     {
-        var response = PostAsync<TResponse>(path).GetAwaiter().GetResult();
-        return response;
+        return PostAsync<TResponse>(path).GetAwaiter().GetResult();
     }
 
     public async Task<TResponse> PostAsync<TResponse>(string path) where TResponse : Models.Management.RestResponseBase
     {
         var uri = new Uri(_settings.BaseUri, path);
-        var opt = new RestClientOptions(uri);
+        using var client = BuildClient(uri);
 
-        opt.Authenticator = new HttpBasicAuthenticator(_settings.Username, _settings.Password);
-        using var client = new RestClient(opt);
-
-        var req = new RestRequest();
-        req.Method = Method.Post;
-
-        req.AddHeader("Saferpay-ApiVersion", SaferPayApiConstants.Version);
-        req.AddHeader("Saferpay-RequestId", Guid.NewGuid().ToString());
-
-        req.AddHeader("Content-Type", "application/json; charset=utf-8");
-        req.AddHeader("Accept", "application/json");
+        var req = new RestRequest { Method = Method.Post };
+        AddManagementHeaders(req);
 
         var res = await client.ExecuteAsync(req);
 
-        // 200 OK
         if (res.IsSuccessful && res.StatusCode == System.Net.HttpStatusCode.OK)
         {
             var response = JsonConvert.DeserializeObject<TResponse>(res.Content ?? "{}", _jsonSerializerSettings);
@@ -427,47 +276,14 @@ public class SaferPayClient : ISaferPayClient
             }
         }
 
-        // 404 Not Found
-        if (res.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            var notFoundError = new ErrorResponse { ErrorMessage = "Requested resource not found (404)." };
-
-            if (!_settings.ThrowExceptionOnFail)
-            {
-                var response = Activator.CreateInstance<TResponse>();
-                response.Error = notFoundError;
-                response.ResponseStatus = Enums.ResponseStatus.ERROR;
-                return response;
-            }
-            throw new SaferPayException(res.StatusCode, notFoundError);
-        }
-
-        // Other Errors (400, 401, 500 vb.)
-        ErrorResponse errorResponse = null;
-        if (!string.IsNullOrEmpty(res.Content))
-        {
-            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(res.Content, _jsonSerializerSettings);
-        }
-
-        errorResponse ??= new ErrorResponse { ErrorMessage = res.ErrorMessage ?? "Unknown API Error" };
-
-        if (!_settings.ThrowExceptionOnFail)
-        {
-            var response = Activator.CreateInstance<TResponse>();
-            response.Error = errorResponse;
-            response.ResponseStatus = Enums.ResponseStatus.ERROR;
-            return response;
-        }
-
-        throw new SaferPayException(res.StatusCode, errorResponse);
+        return HandleErrorResponse<TResponse>(res);
     }
 
     public TResponse Post<TResponse, TRequest>(string path, TRequest request)
         where TResponse : Models.Management.RestResponseBase
         where TRequest : RestRequestBase
     {
-        var response = PostAsync<TResponse, TRequest>(path, request).GetAwaiter().GetResult();
-        return response;
+        return PostAsync<TResponse, TRequest>(path, request).GetAwaiter().GetResult();
     }
 
     public async Task<TResponse> PostAsync<TResponse, TRequest>(string path, TRequest request)
@@ -475,26 +291,17 @@ public class SaferPayClient : ISaferPayClient
         where TRequest : RestRequestBase
     {
         var uri = new Uri(_settings.BaseUri, path);
-        var opt = new RestClientOptions(uri);
+        using var client = BuildClient(uri);
 
-        opt.Authenticator = new HttpBasicAuthenticator(_settings.Username, _settings.Password);
-        using var client = new RestClient(opt);
-
-        var req = new RestRequest();
-        req.Method = Method.Post;
+        var req = new RestRequest { Method = Method.Post };
 
         var json = request.Json();
         req.AddParameter("application/json", json, ParameterType.RequestBody);
 
-        req.AddHeader("Saferpay-ApiVersion", SaferPayApiConstants.Version);
-        req.AddHeader("Saferpay-RequestId", Guid.NewGuid().ToString());
-
-        req.AddHeader("Content-Type", "application/json; charset=utf-8");
-        req.AddHeader("Accept", "application/json");
+        AddManagementHeaders(req);
 
         var res = await client.ExecuteAsync(req);
 
-        // 200 OK
         if (res.IsSuccessful && res.StatusCode == System.Net.HttpStatusCode.OK)
         {
             var response = JsonConvert.DeserializeObject<TResponse>(res.Content ?? "{}", _jsonSerializerSettings);
@@ -505,68 +312,27 @@ public class SaferPayClient : ISaferPayClient
             }
         }
 
-        // 404 Not Found
-        if (res.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            var notFoundError = new ErrorResponse { ErrorMessage = "Requested resource not found (404)." };
-
-            if (!_settings.ThrowExceptionOnFail)
-            {
-                var response = Activator.CreateInstance<TResponse>();
-                response.Error = notFoundError;
-                response.ResponseStatus = Enums.ResponseStatus.ERROR;
-                return response;
-            }
-            throw new SaferPayException(res.StatusCode, notFoundError);
-        }
-
-        // Other Errors (400, 401, 500 vb.)
-        ErrorResponse errorResponse = null;
-        if (!string.IsNullOrEmpty(res.Content))
-        {
-            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(res.Content, _jsonSerializerSettings);
-        }
-
-        errorResponse ??= new ErrorResponse { ErrorMessage = res.ErrorMessage ?? "Unknown API Error" };
-
-        if (!_settings.ThrowExceptionOnFail)
-        {
-            var response = Activator.CreateInstance<TResponse>();
-            response.Error = errorResponse;
-            response.ResponseStatus = Enums.ResponseStatus.ERROR;
-            return response;
-        }
-
-        throw new SaferPayException(res.StatusCode, errorResponse);
+        return HandleErrorResponse<TResponse>(res);
     }
 
     public TResponse Delete<TResponse>(string path) where TResponse : Models.Management.RestResponseBase
     {
-        var response = DeleteAsync<TResponse>(path).GetAwaiter().GetResult();
-        return response;
+        return DeleteAsync<TResponse>(path).GetAwaiter().GetResult();
     }
 
     public async Task<TResponse> DeleteAsync<TResponse>(string path) where TResponse : Models.Management.RestResponseBase
     {
         var uri = new Uri(_settings.BaseUri, path);
-        var opt = new RestClientOptions(uri);
-
-        opt.Authenticator = new HttpBasicAuthenticator(_settings.Username, _settings.Password);
-        using var client = new RestClient(opt);
+        using var client = BuildClient(uri);
 
         var req = new RestRequest(path, Method.Delete);
-
-        req.AddHeader("Saferpay-ApiVersion", SaferPayApiConstants.Version);
-        req.AddHeader("Saferpay-RequestId", Guid.NewGuid().ToString());
-        req.AddHeader("Content-Type", "application/json; charset=utf-8");
-        req.AddHeader("Accept", "application/json");
+        AddManagementHeaders(req);
 
         var res = await client.ExecuteAsync(req);
 
-        // Başarı Durumu (200 OK veya 204 No Content)
+        // Success (200 OK or 204 No Content)
         if (res.IsSuccessful)
         {
-            // 204 No Content durumunda Content null/empty olabilir.
             var content = string.IsNullOrWhiteSpace(res.Content) ? "{}" : res.Content;
             var response = JsonConvert.DeserializeObject<TResponse>(content, _jsonSerializerSettings);
 
@@ -575,72 +341,39 @@ public class SaferPayClient : ISaferPayClient
             return response;
         }
 
-        // 404 Not Found
-        if (res.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            var notFoundError = new ErrorResponse { ErrorMessage = "Requested resource not found (404)." };
-
-            if (!_settings.ThrowExceptionOnFail)
-            {
-                var response = Activator.CreateInstance<TResponse>();
-                response.Error = notFoundError;
-                response.ResponseStatus = Enums.ResponseStatus.ERROR;
-                return response;
-            }
-            throw new SaferPayException(res.StatusCode, notFoundError);
-        }
-
-        // Diğer Hata Durumları
-        ErrorResponse errorResponse = null;
-        if (!string.IsNullOrEmpty(res.Content))
-        {
-            try
-            {
-                errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(res.Content, _jsonSerializerSettings);
-            }
-            catch { /* JSON parse hatası ihtimaline karşı */ }
-        }
-
-        errorResponse ??= new ErrorResponse { ErrorMessage = res.ErrorMessage ?? $"API Error: {res.StatusCode}" };
-
-        if (!_settings.ThrowExceptionOnFail)
-        {
-            var response = Activator.CreateInstance<TResponse>();
-            response.Error = errorResponse;
-            response.ResponseStatus = Enums.ResponseStatus.ERROR;
-            return response;
-        }
-
-        throw new SaferPayException(res.StatusCode, errorResponse);
+        return HandleErrorResponse<TResponse>(res);
     }
 
 
+    /// <summary>
+    /// Build an error response (or throw) for a failed REST (management) call.
+    /// </summary>
     private TResponse HandleErrorResponse<TResponse>(RestResponse res) where TResponse : Models.Management.RestResponseBase
     {
-        // 1. 404 Özel Kontrolü (Genellikle içerik boş döner, bu yüzden manuel mesaj ekliyoruz)
+        if (res == null)
+        {
+            return ProcessFailure<TResponse>(default, new ErrorResponse { ErrorMessage = "No response from server." });
+        }
+
         if (res.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
             var notFoundError = new ErrorResponse { ErrorMessage = "Requested resource not found (404)." };
             return ProcessFailure<TResponse>(res.StatusCode, notFoundError);
         }
 
-        // 2. API'den gelen hata içeriğini (JSON) deserialize etmeye çalışıyoruz
         ErrorResponse errorResponse = null;
         if (!string.IsNullOrEmpty(res.Content))
         {
             try
             {
-                // Saferpay hata formatına göre (Behavior, ErrorName, ErrorMessage vb.) çözümlüyoruz
                 errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(res.Content, _jsonSerializerSettings);
             }
             catch (JsonException)
             {
-                // Yanıt JSON formatında değilse veya beklenmedik bir yapıdaysa
                 errorResponse = new ErrorResponse { ErrorMessage = $"API Parse Error: {res.Content}" };
             }
         }
 
-        // 3. Eğer içerik boşsa veya deserialization başarısız olduysa RestSharp hata mesajlarını kullanıyoruz
         errorResponse ??= new ErrorResponse
         {
             ErrorMessage = !string.IsNullOrEmpty(res.ErrorMessage) ? res.ErrorMessage : $"Server Exception: {res.StatusCode}"
@@ -650,17 +383,62 @@ public class SaferPayClient : ISaferPayClient
     }
 
     /// <summary>
-    /// Ayarlara göre hata fırlatan veya Response nesnesi dönen yardımcı alt metot
+    /// Throws when ThrowExceptionOnFail is set, otherwise returns an ERROR response instance.
     /// </summary>
     private TResponse ProcessFailure<TResponse>(System.Net.HttpStatusCode statusCode, ErrorResponse error) where TResponse : Models.Management.RestResponseBase
     {
         if (_settings.ThrowExceptionOnFail)
         {
-            // Gelişmiş bir exception fırlatıyoruz
             throw new SaferPayException(statusCode, error);
         }
 
-        // Exception istenmiyorsa ERROR statusü ile nesne dönüyoruz
+        var response = Activator.CreateInstance<TResponse>();
+        response.Error = error;
+        response.ResponseStatus = Enums.ResponseStatus.ERROR;
+        return response;
+    }
+
+    /// <summary>
+    /// Build an error response (or throw) for a failed Send call (Core JSON API).
+    /// </summary>
+    private TResponse HandleSendErrorResponse<TResponse>(RestResponse res) where TResponse : ResponseBase
+    {
+        if (res == null)
+        {
+            return ProcessSendFailure<TResponse>(default, new ErrorResponse { ErrorMessage = "No response from server." });
+        }
+
+        ErrorResponse errorResponse = null;
+        if (!string.IsNullOrEmpty(res.Content))
+        {
+            try
+            {
+                errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(res.Content, _jsonSerializerSettings);
+            }
+            catch (JsonException)
+            {
+                errorResponse = new ErrorResponse { ErrorMessage = $"API Parse Error: {res.Content}" };
+            }
+        }
+
+        errorResponse ??= new ErrorResponse
+        {
+            ErrorMessage = !string.IsNullOrEmpty(res.ErrorMessage) ? res.ErrorMessage : $"Server Exception: {res.StatusCode}"
+        };
+
+        return ProcessSendFailure<TResponse>(res.StatusCode, errorResponse);
+    }
+
+    /// <summary>
+    /// Throws when ThrowExceptionOnFail is set, otherwise returns an ERROR response instance.
+    /// </summary>
+    private TResponse ProcessSendFailure<TResponse>(System.Net.HttpStatusCode statusCode, ErrorResponse error) where TResponse : ResponseBase
+    {
+        if (_settings.ThrowExceptionOnFail)
+        {
+            throw new SaferPayException(statusCode, error);
+        }
+
         var response = Activator.CreateInstance<TResponse>();
         response.Error = error;
         response.ResponseStatus = Enums.ResponseStatus.ERROR;


### PR DESCRIPTION
Round 2 after #8, nothing functional this time, just cleanup so the lib is easier to maintain

There were two helper methods sitting in `SaferPayClient` that nobody was calling, so every request method ended up repeating the same error-handling block. I rewired everything through them pulled a couple of small helpers out, and the file shrinks a lot
On the `Channels/` side I also dropped the null checks on `_client` since the field is `readonly` and always set in the ctor, which made every method a one-liner. Plus a tiny empty file in `Helpers/` that nobody actually used

I'm leaving this as a draft on purpose, because I'd rather we see if we can keep things clean and make them more reliable before releasing a new version with every change, so that the next one is spotless

We should also talk a bit about what's next. I'm not exactly sure how the Saferpay documentation aligns with the project, or what parts of the API still need to be implemented :)